### PR TITLE
accessCountが過去60日間のデータはないため削除

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ITboard",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "シャドーITを検知します。対応ブラウザ: Google Chrome, Chromiumベース Microsoft Edge",
   "author": "jimpei",
   "permissions": [

--- a/src/background/js/const.js
+++ b/src/background/js/const.js
@@ -3,7 +3,7 @@ const TermExec = 1;
 
 // 履歴取得範囲(過去60日間)
 const microsecondsPerDay = 1000 * 60 * 60 * 24; // １日
-const DateRange = 1;
+const DateRange = 60;
 const searchStartTime = new Date().getTime() - microsecondsPerDay * DateRange;
 const searchCount = 1000000
 

--- a/src/background/js/const.js
+++ b/src/background/js/const.js
@@ -3,8 +3,8 @@ const TermExec = 1;
 
 // 履歴取得範囲(過去60日間)
 const microsecondsPerDay = 1000 * 60 * 60 * 24; // １日
-const date = 60;
-const searchStartTime = new Date().getTime() - microsecondsPerDay * date;
+const DateRange = 1;
+const searchStartTime = new Date().getTime() - microsecondsPerDay * DateRange;
 const searchCount = 1000000
 
 // 履歴取得条件
@@ -43,6 +43,7 @@ const PostShadowItUrl =
 
 const con = {
   termExec: TermExec,
+  dateRage: DateRange,
   searchQuery: SearchQuery,
   beginHistoryEventTime: BeginHistoryEventTime,
   endHistoryEventTime: EndHistoryEventTime,


### PR DESCRIPTION
■事象
accessCountが指定範囲の過去60日間ではなかったため、getVisitsAPIを使用してデータを細分化
利用頻度はバックエンド側で処理するものとする