### PR TITLE
ITBOARD-2437 シャドーITの拡張機能の分散対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Chrome 閲覧履歴取得のブラウザ拡張機能
 4. 開発者モードを ON
 5. 展開して読み込みでITboard_chrome_extension ディレクトリを選択
 
+## STG環境確認手順
+1. ITboard_chrome_extensionソースコードの[STG確認用]の定数をすべてアンコメント
+2. ITboard_chrome_extensionソースコードの[ローカル確認用]の定数をすべてコメントアウト
+  * 手順1,2の対象ファイル
+    * src/background/js/const.js
+    * src/popup/index.js
+3. ローカルの手順を行う
 ---
 ## 難読化
 ### パッケージのインストール

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Chrome 閲覧履歴取得のブラウザ拡張機能
 4. デベロッパーモードを ON
 5. パッケージ化されていない拡張機能を読み込むをクリック
 6. ITboard_chrome_extension ディレクトリを選択
+7. Chromeの右上に拡張機能のアイコンが存在するので、クリックしてITboaedを固定する
+  * https://www.mochiya.ad.jp/blog/system-dev/detail/chrome_extensions_useful_of_2023#%E6%8B%A1%E5%BC%B5%E6%A9%9F%E8%83%BD%E3%81%AE%E7%AE%A1%E7%90%86
+8. 固定したITboardのアイコンをクリックして動作を確認、エラーが出ていたら対応
+  * 以下例
+  1. ユーザマスタにhogehoge@gmail.comが存在しません。
+  * 対応方法
+    * hogehoge@gmail.comのユーザーが存在するサービスをユーザーマスタに設定する
+9. jobディレクトリにてシャドーITのバッチを実行
+  * 実行コマンド
+    * $ docker compose run job rails daily_batch:shadow_it_detector
+10. ITboardのシャドーIT一覧を確認する
+
 ### Microsoft Edge(Chromiumベースのみ対応)
 1. Microsoft Edge の設定をクリック(ブラウザ右上)
 2. 拡張機能をクリック

--- a/README.md
+++ b/README.md
@@ -21,12 +21,17 @@ Chrome 閲覧履歴取得のブラウザ拡張機能
   * https://www.mochiya.ad.jp/blog/system-dev/detail/chrome_extensions_useful_of_2023#%E6%8B%A1%E5%BC%B5%E6%A9%9F%E8%83%BD%E3%81%AE%E7%AE%A1%E7%90%86
 8. 固定したITboardのアイコンをクリックして動作を確認、エラーが出ていたら対応
   * 以下例
-  1. ユーザマスタにhogehoge@gmail.comが存在しません。
-  * 対応方法
-    * hogehoge@gmail.comのユーザーが存在するサービスをユーザーマスタに設定する
+    1. ユーザマスタにhoge@gmail.comが存在しません。
+    * 対応方法
+      * hoge@gmail.comのユーザーが存在するサービスをユーザーマスタに設定する
+    2. Google Workspaceアカウントでログインし、同期を有効にしてください。
+    * 対応方法
+      * https://support.google.com/chrome/answer/185277?hl=ja&co=GENIE.Platform%3DDesktop#zippy=%2C%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%97%E3%81%A6%E5%90%8C%E6%9C%9F%E3%82%92%E3%82%AA%E3%83%B3%E3%81%AB%E3%81%99%E3%82%8B
 9. jobディレクトリにてシャドーITのバッチを実行
   * 実行コマンド
-    * $ docker compose run job rails daily_batch:shadow_it_detector
+```
+$ docker compose run job rails daily_batch:shadow_it_detector
+```
 10. ITboardのシャドーIT一覧を確認する
 
 ### Microsoft Edge(Chromiumベースのみ対応)
@@ -44,7 +49,7 @@ Chrome 閲覧履歴取得のブラウザ拡張機能
     * src/popup/index.js
 3. ローカルの手順を行う
 ---
-## 難読化
+## 難読化(リリース時のみ実行)
 ### パッケージのインストール
 ```
 npm install terser -g
@@ -71,7 +76,7 @@ terser -c -m -o src/background/js/common.js -- src/background/js/common.js && te
 ### 以下の順序でリリース(zipファイル化)
 1. manifest.jsonの versionを更新
   * 例: "0.0.1" → "0.0.2"
-  * manifest_versionではないです
+  * ※ 上記 manifest_versionではないです
 2. versionを更新したのでgithubにあげる
 3. manifest.jsonの 「"http://localhost:3000/","https://stg-01.itboard.jp/"」を削除
 4. リクエスト先を本番用に変更

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ITboard",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "シャドーITを検知します。対応ブラウザ: Google Chrome, Chromiumベース Microsoft Edge",
   "author": "jimpei",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ITboard",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "シャドーITを検知します。対応ブラウザ: Google Chrome, Chromiumベース Microsoft Edge",
   "author": "jimpei",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ITboard",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "シャドーITを検知します。対応ブラウザ: Google Chrome, Chromiumベース Microsoft Edge",
   "author": "jimpei",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ITboard",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "シャドーITを検知します。対応ブラウザ: Google Chrome, Chromiumベース Microsoft Edge",
   "author": "jimpei",
   "permissions": [

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -15,14 +15,11 @@ export const postBatchDataEvent = async (email) => {
     if (response.ok) {
       const data = await response.json();
 
-      // 分割(distributeHour)
-      //  1の場合: calcDistribute == 60分
-      //  2の場合: calcDistribute == 120分
-      const calcDistribute = data.distributeHour * 60;
+      const calcDistribute = (data.endHistoryEventTime - data.beginHistoryEventTime) * 60;
       let requestIndex = data.requestIndex;
 
-      // ９時に履歴取得開始
       // calcDistributeの値に応じてユーザーのリクエスト時間を配分
+      //
       // case1
       //   requestIndex: 10, calcDistribute: 60
       //    └ 9:10にリクエスト
@@ -39,8 +36,13 @@ export const postBatchDataEvent = async (email) => {
       // requestIndexがcalcDistributeより少ない場合 (case1とcase3)
       // そのままrequestIndexを保存
       let num = requestIndex / calcDistribute;
+
       if (num < 1) {
-        chrome.storage.local.set({ requestIndex: requestIndex });
+        chrome.storage.local.set({
+          requestIndex: requestIndex,
+          beginHistoryEventTime: data.beginHistoryEventTime,
+          endHistoryEventTime: data.endHistoryEventTime
+        });
         return requestIndex;
       }
 
@@ -57,7 +59,11 @@ export const postBatchDataEvent = async (email) => {
         requestIndex -= calcDistribute;
         num = requestIndex / calcDistribute;
         if (num < 1) {
-          chrome.storage.local.set({ requestIndex: requestIndex });
+          chrome.storage.local.set({
+            requestIndex: requestIndex,
+            beginHistoryEventTime: data.beginHistoryEventTime,
+            endHistoryEventTime: data.endHistoryEventTime
+          });
           return requestIndex;
         }
       }
@@ -142,12 +148,16 @@ export const formatDate = (date) => {
   return null;
 };
 
-export const requestTimeData = (requestIndex, now) => {
+export const requestTimeData = (
+  requestIndex,
+  beginHistoryEventTime,
+  now
+) => {
   const requestTime = new Date();
   const nowHours = now.getHours();
   const nowMinitue = now.getMinutes();
   const setRequestTime = requestTime.setHours(
-    con.beginHistoryEventTime,
+    beginHistoryEventTime,
     requestIndex,
     0
   );

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -66,40 +66,63 @@ export const postBatchDataEvent = async (email) => {
 };
 
 // ブラウザ履歴取得
-export const historyEvent = (email) => {
+export const historyEvent = async (email) => {
   try {
     const browser = historyByBrowser();
+    chrome.history.search(con.searchQuery, async (accessItems) => {
+      // 履歴データ形成
+      const data = await formatHistoryData(accessItems)
 
-    const accessArray = []
-    chrome.history.search(con.searchQuery, (accessItems) => {
-      for (let i = 0; i < accessItems.length; i++) {
-        const accessObj = {};
-
-        // クエリパラメータ除外
-        accessObj["url"] = accessItems[i].url.replace(/\?.*$/, "");
-        accessObj["title"] = accessItems[i].title;
-        accessObj["accessCount"] = accessItems[i].visitCount;
-        accessObj["lastAccessDate"] = new Date(accessItems[i].lastVisitTime);
-
-        const accessData = accessObj;
-        accessArray.push(accessData);
-      }
-    // 履歴データPOST
-      fetch(con.postShadowItUrl, {
-        headers:{
-          'Accept': 'application/json, */*',
-          'Content-type':'application/json'
-        },
-        method: "POST",
-        body: JSON.stringify({
-          email: email,
-          browser: browser,
-          data: accessArray
-        }),
-      });
+      // TODO: 非同期処理をしてもdataになぜか値がはいらない
+      // setTimeoutで遅延させると成功する
+      setTimeout(() => {
+        fetch(con.postShadowItUrl, {
+          headers:{
+            'Accept': 'application/json, */*',
+            'Content-type':'application/json'
+          },
+          method: "POST",
+          body: JSON.stringify({
+            email: email,
+            browser: browser,
+            data: data
+          }),
+        });
+      }, "100")
     });
   } catch(e) { console.log(`${e} from historyEvent `) }
 };
+
+const formatHistoryData = async (accessItems) => {
+  const accessArray = []
+
+  for (let i = 0; i < accessItems.length; i++) {
+    const urlObj = { url: accessItems[i].url }
+
+    // history.searchのvisitCountが指定期間(過去60日間)の範囲の利用回数ではないため、
+    // getVisitsを使用し、指定期間の範囲ではないデータは除外したデータを形成する
+    chrome.history.getVisits(urlObj, (gettingVisits) => {
+      const accessObj = {};
+
+      for (let n = 0; n < gettingVisits.length; n++) {
+        const visitData = gettingVisits[n]
+        const visitTime = new Date(visitData.visitTime)
+        const now = new Date()
+        const visitRange = new Date(now.setDate(now.getDate() - con.dateRage))
+
+        // ログイン日時が指定期間(過去60日間)以内ではない場合は形成しない
+        if (visitTime > visitRange) {
+          accessObj["url"] = accessItems[i].url.replace(/\?.*$/, "");
+          accessObj["title"] = accessItems[i].title;
+          accessObj["lastAccessDate"] = visitTime;
+
+          accessArray.push(accessObj);
+        }
+      }
+    });
+  }
+  return accessArray
+}
 
 // 履歴取得したブラウザを判別
 const historyByBrowser = () => {

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -81,6 +81,7 @@ export const historyEvent = async (email) => {
 
       // TODO: 非同期処理をしてもdataになぜか値がはいらない
       // setTimeoutで遅延させると成功する
+      // ブラウザ起動時にsetTimeoutの秒数が短いとデータ形成ができずにエラーになるため5秒間とする
       setTimeout(() => {
         fetch(con.postShadowItUrl, {
           headers:{
@@ -94,7 +95,7 @@ export const historyEvent = async (email) => {
             data: data
           }),
         });
-      }, "100")
+      }, "5000")
     });
   } catch(e) { console.log(`${e} from historyEvent `) }
 };

--- a/src/background/js/const.js
+++ b/src/background/js/const.js
@@ -2,25 +2,21 @@
 const TermExec = 1;
 
 // 履歴取得範囲(過去60日間)
-const microsecondsPerDay = 1000 * 60 * 60 * 24; // １日
+const MicrosecondsPerDay = 1000 * 60 * 60 * 24; // １日
 const DateRange = 60;
-const searchStartTime = new Date().getTime() - microsecondsPerDay * DateRange;
-const searchCount = 1000000
+const SearchStartTime = new Date().getTime() - MicrosecondsPerDay * DateRange;
+const SearchCount = 1000000
 
 // 履歴取得条件
 const SearchQuery = {
   text: "",
-  startTime: searchStartTime,
-  maxResults: searchCount,
+  startTime: SearchStartTime,
+  maxResults: SearchCount,
 };
 
-// 業務時間内の範囲
-const BeginHistoryEventTime = 9;
-const EndHistoryEventTime = 17;
-
 // ユーザリクエスト順序ができない場合のランダム値
-const randomHour = 8;
-const RandomIndex = Math.floor(Math.random()*((randomHour * 60)-0)+0);
+const RandomHour = 8;
+const RandomIndex = Math.floor(Math.random()*((RandomHour * 60)-0)+0);
 
 // リクエスト先
 // ローカル確認用
@@ -51,8 +47,6 @@ const con = {
   termExec: TermExec,
   dateRage: DateRange,
   searchQuery: SearchQuery,
-  beginHistoryEventTime: BeginHistoryEventTime,
-  endHistoryEventTime: EndHistoryEventTime,
   randomIndex: RandomIndex,
   postDistributeUrl: PostDistributeUrl,
   postShadowItUrl: PostShadowItUrl,

--- a/src/background/js/const.js
+++ b/src/background/js/const.js
@@ -28,18 +28,24 @@ const PostDistributeUrl =
   "http://localhost:3000/v1/browser-extensions/distribute";
 const PostShadowItUrl =
   "http://localhost:3000/v1/browser-extensions/browsing-histories";
+const GetUninstallUrl =
+  "http://localhost:3000/v1/browser-extensions/uninstall"
 
 // STG確認用
 // const PostDistributeUrl =
 //   'https://stg-01.itboard.jp/api/v1/browser-extensions/distribute'
 // const PostShadowItUrl =
 //   'https://stg-01.itboard.jp/api/v1/browser-extensions/browsing-histories'
+// const GetUninstallUrl =
+//   'https://stg-01.itboard.jp/api/v1/browser-extensions/uninstall'
 
 // 本番用
 // const PostDistributeUrl =
 //   'https://www.itboard.jp/api/v1/browser-extensions/distribute'
 // const PostShadowItUrl =
 //   'https://www.itboard.jp/api/v1/browser-extensions/browsing-histories'
+// const GetUninstallUrl =
+//   'https://www.itboard.jp/api/v1/browser-extensions/uninstall'
 
 const con = {
   termExec: TermExec,
@@ -50,6 +56,7 @@ const con = {
   randomIndex: RandomIndex,
   postDistributeUrl: PostDistributeUrl,
   postShadowItUrl: PostShadowItUrl,
+  getUninstallUrl: GetUninstallUrl,
 };
 
 Object.freeze(con);

--- a/src/background/js/const.js
+++ b/src/background/js/const.js
@@ -3,8 +3,8 @@ const TermExec = 1;
 
 // 履歴取得範囲(過去60日間)
 const microsecondsPerDay = 1000 * 60 * 60 * 24; // １日
-const date = 60;
-const searchStartTime = new Date().getTime() - microsecondsPerDay * date;
+const DateRange = 60;
+const searchStartTime = new Date().getTime() - microsecondsPerDay * DateRange;
 const searchCount = 1000000
 
 // 履歴取得条件
@@ -43,6 +43,7 @@ const PostShadowItUrl =
 
 const con = {
   termExec: TermExec,
+  dateRage: DateRange,
   searchQuery: SearchQuery,
   beginHistoryEventTime: BeginHistoryEventTime,
   endHistoryEventTime: EndHistoryEventTime,

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -29,6 +29,7 @@ export const backgroundEvent = () => {
 const installEvent = () => {
   chrome.identity.getProfileUserInfo((user) => {
     if (user.email) {
+      setUninstallUrl(user.email);
       postBatchDataEvent(user.email).then(value => {
 
         if (value !== "undefined") {
@@ -45,6 +46,10 @@ const installEvent = () => {
 // 履歴情報取得(定期)
 const batchEvent = (alarm) => {
   chrome.identity.getProfileUserInfo((user) => {
+    if (user.email) {
+      setUninstallUrl(user.email);
+    }
+
     if (user.email && alarm.name == "start_batch") {
 
       chrome.storage.local.get([
@@ -101,4 +106,10 @@ const getRequestIndex = (user, storage, now) => {
       });
     }
   }
+};
+
+const setUninstallUrl = (userEmail) => {
+  chrome.runtime.setUninstallURL(
+    con.getUninstallUrl + '?email=' + userEmail
+  )
 };

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -134,6 +134,7 @@ const getRequestIndex = (user, storage, now) => {
   }
 };
 
+// 拡張機能アンインストール時、GETリクエストでシャドーIT拡張機能に関連するデータを削除する。
 const setUninstallUrl = (userEmail) => {
   chrome.runtime.setUninstallURL(
     con.getUninstallUrl + '?email=' + userEmail

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -51,8 +51,8 @@ const postDistributeUrl =
 
 // STG確認用
 // const postDistributeUrl =
-//   'https://stg-01.itboard.jp/v1/browser-extensions/distribute'
+//   'https://stg-01.itboard.jp/api/v1/browser-extensions/distribute'
 
 // 本番用
 // const postDistributeUrl =
-//   'https://www.itboard.jp/v1/browser-extensions/distribute'
+//   'https://www.itboard.jp/api/v1/browser-extensions/distribute'

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,3 +1,16 @@
+// 履歴取得範囲(過去60日間)
+const popupMicrosecondsPerDay = 1000 * 60 * 60 * 24; // １日
+const popupDateRange = 60;
+const popupSearchStartTime = new Date().getTime() - popupMicrosecondsPerDay * popupDateRange;
+const popupSearchCount = 1000000
+
+// 履歴取得条件
+const popupSearchQuery = {
+  text: "",
+  startTime: popupSearchStartTime,
+  maxResults: popupSearchCount,
+};
+
 // ポップアップ表示
 document.addEventListener('DOMContentLoaded', () => {
   chrome.identity.getProfileUserInfo(async (user) => {
@@ -11,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       el.innerText = '正常に動作しています。'
       el.style.width = '140px'
+      popupEvent();
     }
 
     document.body.appendChild(el);
@@ -45,14 +59,118 @@ const existsInUserMaster = async (user) => {
   } catch(e) { console.log(`${e} from existsInUserMaster `) }
 }
 
+const popupEvent = () => {
+  chrome.storage.local.get(["postTimestamp"], (storage) => {
+    const now = new Date();
+    const nowDate = popupFormatDate(now);
+    const postHistoryDate = popupFormatDate(new Date(storage.postTimestamp));
+
+    // 既に履歴を送信している場合は処理を行わない
+    if (postHistoryDate !== nowDate) {
+      chrome.identity.getProfileUserInfo((user) => {
+        if (user.email) {
+          chrome.storage.local.set({ postTimestamp: now.getTime() });
+          popupHistoryEvent(user.email);
+        }
+      });
+    }
+  })
+}
+
+// YYYY/MM/DD形式に変換
+const popupFormatDate = (date) => {
+  if (date) {
+    return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+  }
+  return null;
+};
+
+// ブラウザ履歴取得
+const popupHistoryEvent = async (email) => {
+  try {
+    const browser = popupHistoryByBrowser();
+    chrome.history.search(popupSearchQuery, async (accessItems) => {
+      // 履歴データ形成
+      const data = await popupFormatHistoryData(accessItems)
+
+      // TODO: 非同期処理をしてもdataになぜか値がはいらない
+      // setTimeoutで遅延させると成功する
+      // ポップアップ: 0.1秒間
+      // ブラウザ起動時: 5秒間
+      setTimeout(() => {
+        fetch(postShadowItUrl, {
+          headers:{
+            'Accept': 'application/json, */*',
+            'Content-type':'application/json'
+          },
+          method: "POST",
+          body: JSON.stringify({
+            email: email,
+            browser: browser,
+            data: data
+          }),
+        });
+      }, "100")
+    });
+  } catch(e) { console.log(`${e} from popupHistoryEvent `) }
+};
+
+// 履歴取得したブラウザを判別
+const popupHistoryByBrowser = () => {
+  const agent = navigator.userAgent.toLowerCase()
+  if (agent.indexOf("edg") != -1) {
+    return 'edge'
+  } else {
+    return 'chrome'
+  }
+};
+
+
+const popupFormatHistoryData = async (accessItems) => {
+  const accessArray = []
+
+  for (let i = 0; i < accessItems.length; i++) {
+    const urlObj = { url: accessItems[i].url }
+
+    // history.searchのvisitCountが指定期間(過去60日間)の範囲の利用回数ではないため、
+    // getVisitsを使用し、指定期間の範囲ではないデータは除外したデータを形成する
+    chrome.history.getVisits(urlObj, (gettingVisits) => {
+      const accessObj = {};
+
+      for (let n = 0; n < gettingVisits.length; n++) {
+        const visitData = gettingVisits[n]
+        const visitTime = new Date(visitData.visitTime)
+        const now = new Date()
+        const visitRange = new Date(now.setDate(now.getDate() - popupDateRange))
+
+        // ログイン日時が指定期間(過去60日間)以内ではない場合は形成しない
+        if (visitTime > visitRange) {
+          accessObj["url"] = accessItems[i].url.replace(/\?.*$/, "");
+          accessObj["title"] = accessItems[i].title;
+          accessObj["lastAccessDate"] = visitTime;
+
+          accessArray.push(accessObj);
+        }
+      }
+    });
+  }
+  return accessArray
+}
+
 // ローカル確認用
 const postDistributeUrl =
   "http://localhost:3000/v1/browser-extensions/distribute";
+const postShadowItUrl =
+  "http://localhost:3000/v1/browser-extensions/browsing-histories";
 
 // STG確認用
 // const postDistributeUrl =
 //   'https://stg-01.itboard.jp/api/v1/browser-extensions/distribute'
+// const postShadowItUrl =
+//   'https://stg-01.itboard.jp/api/v1/browser-extensions/browsing-histories'
 
 // 本番用
 // const postDistributeUrl =
 //   'https://www.itboard.jp/api/v1/browser-extensions/distribute'
+// const postShadowItUrl =
+//   'https://www.itboard.jp/api/v1/browser-extensions/browsing-histories'

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -22,7 +22,7 @@ const addPopupByBrowser = (el) => {
   const agent = window.navigator.userAgent.toLowerCase()
 
   if (agent.indexOf("edg") != -1) {
-    el.innerText = 'Office365アカウントでサインインし、同期を有効にしてください。'
+    el.innerText = 'Microsoftアカウントでサインインし、同期を有効にしてください。'
     el.style.width = '220px'
   } else {
     el.innerText = 'Google Workspaceアカウントでログインし、同期を有効にしてください。'


### PR DESCRIPTION
## 対応内容
  - 履歴データ送信時間をバックエンド側の設定変更により、拡張機能に反映されるようにロジック変更
    - 月の初め(1日)に参照していたブラウザのローカルストレージ送信時間帯が変更される 
  - シャドーITフェーズ2にて、バックエンド側もこの拡張機能に対応した内容になるため、フェーズ２リリース後に拡張機能もリリースする

## バックエンド側PR
https://github.com/SB-CORP-ITboard/ITboard/pull/992

## RV期日
5/8