### PR TITLE
ITBOARD-3411 毎日60日分のブラウザ履歴を送信させず、最終送信日から送信時点で貯まったブラウザ履歴を送信し、DB側で過去60日分を蓄積する仕様に変更

### DIFF
--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -3,10 +3,11 @@ import { con } from "./const.js";
 export const historyEvent = async (email, beforePostTimestamp = undefined) => {
   try {
     const browser = historyByBrowser();
-    if (beforePostTimestamp != undefined) {
-      con.searchQuery.startTime = beforePostTimestamp
-    }
-    chrome.history.search(con.searchQuery, async (accessItems) => {
+    const searchQuery = {
+      ...con.searchQuery,
+      startTime: beforePostTimestamp || con.searchQuery.startTime
+    };
+    chrome.history.search(searchQuery, async (accessItems) => {
       try {
         // 履歴データ形成（Promiseで確実にデータを取得）
         const data = await formatHistoryData(accessItems);

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -1,8 +1,11 @@
 import { con } from "./const.js";
 
-export const historyEvent = async (email) => {
+export const historyEvent = async (email, postTimestamp = undefined) => {
   try {
     const browser = historyByBrowser();
+    if (postTimestamp != undefined) {
+      con.searchQuery.startTime = postTimestamp
+    }
     chrome.history.search(con.searchQuery, async (accessItems) => {
       try {
         // 履歴データ形成（Promiseで確実にデータを取得）

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -1,10 +1,10 @@
 import { con } from "./const.js";
 
-export const historyEvent = async (email, postTimestamp = undefined) => {
+export const historyEvent = async (email, beforePostTimestamp = undefined) => {
   try {
     const browser = historyByBrowser();
-    if (postTimestamp != undefined) {
-      con.searchQuery.startTime = postTimestamp
+    if (beforePostTimestamp != undefined) {
+      con.searchQuery.startTime = beforePostTimestamp
     }
     chrome.history.search(con.searchQuery, async (accessItems) => {
       try {

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -11,11 +11,6 @@ export const backgroundEvent = () => {
     installEvent();
   });
 
-  // ブラウザ起動時
-  chrome.runtime.onStartup.addListener(() => {
-    startUpEvent();
-  });
-
   // 新しいタブが開かれた時 or タブ内で画面遷移した時
   chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status === 'complete' && tab.active) {
@@ -73,17 +68,6 @@ const shouldSendHistory = (callback) => {
     });
   });
 };
-
-// 履歴情報取得(ブラウザ起動時)
-const startUpEvent = () => {
-  shouldSendHistory((shouldSend, user) => {
-    if (shouldSend && user && user.email) {
-      const now = new Date();
-      chrome.storage.local.set({ postTimestamp: now.getTime() });
-      historyEvent(user.email);
-    }
-  });
-}
 
 // 拡張機能アンインストール時、GETリクエストでシャドーIT拡張機能に関連するデータを削除する。
 const setUninstallUrl = (userEmail) => {

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -35,9 +35,14 @@ const installEvent = () => {
 const tabNavigationEvent = () => {
   shouldSendHistory((shouldSend, user) => {
     if (shouldSend && user && user.email) {
-      const now = new Date();
-      chrome.storage.local.set({ postTimestamp: now.getTime() });
-      historyEvent(user.email);
+      chrome.storage.local.get(["postTimestamp"], (storage) => {
+        const now = new Date();
+        chrome.storage.local.set({ postTimestamp: now.getTime() });
+        // postTimestamp の値の型が null か undefined の場合は履歴を送信しない
+        if (postTimestamp != null) {
+          historyEvent(user.email, storage.postTimestamp);
+        }
+      })
     }
   });
 };


### PR DESCRIPTION
## チケット
[ITBOARD-3411](https://itcrowd.backlog.com/view/ITBOARD-3411) 毎日60日分のブラウザ履歴を送信させず、最終送信日から送信時点で貯まったブラウザ履歴を送信し、DB側で過去60日分を蓄積する仕様に変更

## 対応内容
[backlogチケット詳細の「設計＞拡張機能側」項目](https://itcrowd.backlog.com/view/ITBOARD-3411#:~:text=%E8%A8%AD%E8%A8%88-,%E6%8B%A1%E5%BC%B5%E6%A9%9F%E8%83%BD%E5%81%B4,-%E5%B1%A5%E6%AD%B4%E9%80%81%E4%BF%A1%E3%82%BF%E3%82%A4%E3%83%9F%E3%83%B3%E3%82%B0)に記載

## Rails 側のチケット
https://github.com/SB-CORP-ITboard/ITboard/pull/1438

## RV期限
6月12日(木)