### PR TITLE
ITBOARD-3410 同一人物の複数環境からのブラウザ履歴を検知できるようにする

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ITboard",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "シャドーITを検知します。対応ブラウザ: Google Chrome, Chromiumベース Microsoft Edge",
   "author": "jimpei",
   "permissions": [

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -349,11 +349,6 @@ const postDevice = async (email, browser) => {
 };
 
 export const changeStorageEvent = (changes, areaName) => {
-  if (isStorageUpdate) {
-    isStorageUpdate = false;
-    return;
-  }
-
   if (areaName !== 'local') {
     return;
   }

--- a/src/background/js/common.js
+++ b/src/background/js/common.js
@@ -297,119 +297,122 @@ const sendHistoryLogData = (email, browser, data, sendId, timestamp, manifest, d
 };
 
 export const postDeviceEvent = async (email) => {
-  return new Promise((resolve) => {
-    chrome.storage.local.get('device_id', async (storage) => {
-      if (storage.device_id) {
-        resolve(storage.device_id);
-        return;
-      }
+  try {
+    const storage = await chrome.storage.local.get('device_id');
 
-      try {
-        const browser = historyByBrowser();
-        const response = await fetch(con.deviceUrl, {
-          headers:{
-            'Accept': 'application/json, */*',
-            'Content-type':'application/json'
-          },
-          method: 'POST',
-          body: JSON.stringify({ email, browser }),
-        });
+    if (storage.device_id) {
+      return storage.device_id;
+    }
 
-        if (!response.ok) {
-          console.error(`[ITboard] device 作成リクエスト失敗: ${response.status}`);
-          resolve(null);
-          return;
-        }
+    const browser = historyByBrowser();
 
-        const data = await response.json();
-        const deviceId = data.device_id;
-
-        if (deviceId) {
-          chrome.storage.local.set({ device_id: deviceId });
-          resolve(deviceId);
-        } else {
-          console.error(`[ITboard] device_id がレスポンスに含まれていません`);
-        }
-      } catch (e) {
-        console.error(`[ITboard] postDeviceEvent 内で例外が発生: ${e}`);
-        resolve(null);
-      }
+    const response = await fetch(con.deviceUrl, {
+      headers:{
+        'Accept': 'application/json, */*',
+        'Content-type':'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify({ email, browser }),
     });
-  });
+
+    if (!response.ok) {
+      throw new Error(`[ITboard] device 作成リクエスト失敗: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const deviceId = data.device_id;
+
+    if (deviceId) {
+      chrome.storage.local.set({ device_id: deviceId });
+      return deviceId;
+    } else {
+      throw new Error(`[ITboard] device_id がレスポンスに含まれていません`);
+    }
+
+  } catch (e) {
+    console.error(e.message);
+    return null;
+  }
 };
 
-export const changeStorageEvent = async (changes, areaName) => {
+let isStorageUpdate = false;
+
+export const changeStorageEvent = (changes, areaName) => {
+  if (isInternalUpdate) {
+    isInternalUpdate = false;
+    return;
+  }
+
   if (areaName !== 'local') {
     return;
   }
 
-  // device_id が変更された場合の処理
-  if (changes.device_id) {
-    const { oldValue, newValue } = changes.device_id;
+  if (!changes.device_id && !changes.postTimestamp) {
+    return;
+  }
 
-    // device_id が実際に変更された場合のみ実行
-    if (oldValue && oldValue !== newValue) {
-      chrome.identity.getProfileUserInfo(async (user) => {
-        if (user.email) {
-          const browser = historyByBrowser();
+  chrome.identity.getProfileUserInfo(async (user) => {
+    try {
+      if (user.email) {
+        const browser = historyByBrowser();
+        // device_id が変更された場合の処理
+        if (changes.device_id) {
+          const { oldValue, newValue } = changes.device_id;
 
-          const device = await getDevice(oldValue, user.email, browser);
+          if (oldValue !== newValue) {
+            const device = await getDevice(oldValue, user.email, browser);
 
-          if (device && device.device_id) {
-            chrome.storage.local.set({ device_id: device.device_id }, () => {
+            if (device && device.device_id) {
+              isInternalUpdate = true;
+              await chrome.storage.local.set({ device_id: device.device_id });
               console.log(`[ITboard] device_id を再設定: ${device.device_id}`);
-            });
-          } else {
-            console.error('[ITboard] レスポンスから device_id を取得失敗');
+            } else {
+              throw new Error('[ITboard] レスポンスから device_id を取得失敗');
+            }
           }
         }
-      });
-    }
-  }
 
-  // postTimestamp が削除された場合の処理
-  if (changes.postTimestamp) {
-    const { oldValue, newValue } = changes.postTimestamp;
+        // postTimestamp が変更された場合の処理
+        if (changes.postTimestamp) {
+          const { oldValue, newValue } = changes.postTimestamp;
 
-    // device_id が実際に変更された場合のみ実行
-    if (oldValue && oldValue !== newValue) {
-      chrome.identity.getProfileUserInfo(async (user) => {
-        if (user.email) {
-          const storage = await chrome.storage.local.get('device_id');
-          const deviceId = storage.device_id;
+          if (oldValue !== newValue) {
+            const storage = await chrome.storage.local.get('device_id');
+            const deviceId = storage.device_id;
 
-          if (!deviceId) {
-            console.error('[ITboard] device_idがローカルストレージに見つからないため、postTimestampの再取得を中断');
-            return;
-          }
+            if (!deviceId) {
+              throw new Error('[ITboard] ローカルストレージからdevice_id 取得失敗');
+            }
 
-          const browser = historyByBrowser();
+            const device = await getDevice(deviceId, user.email, browser);
 
-          const device = await getDevice(deviceId, user.email, browser);
-
-          if (device && device.last_request_at) {
-            chrome.storage.local.set({ postTimestamp: device.last_request_at }, () => {
+            if (device && device.last_request_at) {
+              isInternalUpdate = true;
+              await chrome.storage.local.set({ postTimestamp: device.last_request_at });
               console.log(`[ITboard] postTimestamp を再設定: ${device.last_request_at}`);
-            });
-          } else {
-            console.error('[ITboard] レスポンスから last_request_at を取得失敗');
+            } else {
+              throw new Error('[ITboard] レスポンスから last_request_at を取得失敗');
+            }
           }
         }
-      });
+      }
+    } catch (e) {
+      isInternalUpdate = false;
+      console.error(e.message);
     }
-  }
+  });
 };
 
 const getDevice = async (deviceId, email, browser) => {
-  const params = new URLSearchParams({
-    device_id: deviceId,
-    email: email,
-    browser: browser,
-  });
-
-  const url = `${con.deviceUrl}?${params.toString()}`;
-
   try {
+    const params = new URLSearchParams({
+      device_id: deviceId,
+      email: email,
+      browser: browser,
+    });
+
+    const url = `${con.deviceUrl}?${params.toString()}`;
+
     const response = await fetch(url, {
       method: "GET",
       headers: {
@@ -419,15 +422,14 @@ const getDevice = async (deviceId, email, browser) => {
     });
 
     if (!response.ok) {
-      console.error(`[ITboard] 取得リクエスト失敗: ${response.status}`);
-      return null;
+      throw new Error(`[ITboard] device 取得リクエスト失敗: ${response.status}`);
     }
 
     const data = await response.json();
     return data;
 
   } catch (e) {
-    console.error(`[ITboard] getDevice 内で例外発生: ${e}`);
+    console.error(e.message);
     return null;
   }
 };

--- a/src/background/js/const.js
+++ b/src/background/js/const.js
@@ -14,33 +14,39 @@ const SearchQuery = {
 // リクエスト先
 // ローカル確認用
 const PostShadowItUrl =
-  "http://localhost:3000/v1/browser-extensions/browsing-histories";
+  "http://localhost:3000/v1/browser-extensions/browsing-histories_with_device";
 const PostHistoryLogUrl =
   "http://localhost:3000/v1/browser-extension-logs/history";
 const PostErrorLogUrl =
   "http://localhost:3000/v1/browser-extension-logs";
 const GetUninstallUrl =
-  "http://localhost:3000/v1/browser-extensions/uninstall"
+  "http://localhost:3000/v1/browser-extensions/uninstall_with_device"
+const DeviceUrl =
+  "http://localhost:3000/v1/extension_browsing_history_devices"
 
 // STG確認用
 // const PostShadowItUrl =
-//   'https://stg-01.itboard.jp/api/v1/browser-extensions/browsing-histories'
+//   'https://stg-01.itboard.jp/api/v1/browser-extensions/browsing-histories_with_device'
 // const PostHistoryLogUrl =
 //   'https://stg-01.itboard.jp/api/v1/browser-extension-logs/history'
 // const PostErrorLogUrl =
 //   'https://stg-01.itboard.jp/api/v1/browser-extension-logs'
 // const GetUninstallUrl =
-//   'https://stg-01.itboard.jp/api/v1/browser-extensions/uninstall'
+//   'https://stg-01.itboard.jp/api/v1/browser-extensions/uninstall_with_device'
+// const DeviceUrl =
+//   "https://stg-01.itboard.jp/api/v1/extension_browsing_history_devices"
 
 // 本番用
 // const PostShadowItUrl =
-//   'https://www.itboard.jp/api/v1/browser-extensions/browsing-histories'
+//   'https://www.itboard.jp/api/v1/browser-extensions/browsing-histories_with_device'
 // const PostHistoryLogUrl =
 //   'https://www.itboard.jp/api/v1/browser-extension-logs/history'
 // const PostErrorLogUrl =
 //   'https://www.itboard.jp/api/v1/browser-extension-logs'
 // const GetUninstallUrl =
-//   'https://www.itboard.jp/api/v1/browser-extensions/uninstall'
+//   'https://www.itboard.jp/api/v1/browser-extensions/uninstall_with_device'
+// const DeviceUrl =
+//   "https://www.itboard.jp/api/v1/extension_browsing_history_devices"
 
 const con = {
   dateRange: DateRange,
@@ -49,6 +55,7 @@ const con = {
   postHistoryLogUrl: PostHistoryLogUrl,
   postErrorLogUrl: PostErrorLogUrl,
   getUninstallUrl: GetUninstallUrl,
+  deviceUrl: DeviceUrl
 };
 
 Object.freeze(con);

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -54,14 +54,14 @@ export const backgroundEvent = () => {
 const installEvent = () => {
   chrome.identity.getProfileUserInfo(async (user) => {
     try {
+      const now = new Date();
+
       setStorageUpdateFlag(true);
       await chrome.storage.local.set({ postTimestamp: now.getTime() });
 
       if (!user || !user.email) {
         throw new Error("[ITboard] email取得失敗");
       }
-
-      const now = new Date();
 
       const deviceId = await postDeviceEvent(user.email);
 

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -11,8 +11,10 @@ import { con } from "./const.js";
 // 各タイミングで処理を行う
 export const backgroundEvent = () => {
   // インストール時
-  chrome.runtime.onInstalled.addListener(() => {
-    installEvent();
+  chrome.runtime.onInstalled.addListener((details) => {
+    if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
+      installEvent();
+    }
   });
 
   // 新しいタブが開かれた時 or タブ内で画面遷移した時

--- a/src/background/js/index.js
+++ b/src/background/js/index.js
@@ -53,6 +53,7 @@ export const backgroundEvent = () => {
   });
 };
 
+// 履歴情報取得(インストール時)
 const installEvent = () => {
   chrome.identity.getProfileUserInfo(async (user) => {
     try {

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -59,30 +59,40 @@ const existsInUserMaster = async (user) => {
   } catch(e) { console.log(`${e} from existsInUserMaster `) }
 }
 
-const popupEvent = () => {
-  chrome.storage.local.get(["postTimestamp"], (storage) => {
+const popupEvent = async () => {
+  try {
+    const storage = await chrome.storage.local.get(["postTimestamp"]);
+
     const now = new Date();
     const nowDate = popupFormatDate(now);
     const postHistoryDate = popupFormatDate(new Date(storage.postTimestamp));
 
-    // 既に履歴を送信している場合は処理を行わない
-    if (postHistoryDate !== nowDate) {
-      chrome.identity.getProfileUserInfo(async (user) => {
-        if (user.email) {
-          const deviceId = await popupPostDeviceEvent(user.email);
+    if (postHistoryDate === nowDate) { return }
 
-          if (!deviceId) {
-            console.error("[ITboard] device_id 取得処理失敗");
-            return;
-          }
+    const user = await chrome.identity.getProfileUserInfo();
 
-          chrome.storage.local.set({ postTimestamp: now.getTime() });
-          popupHistoryEvent(user.email, deviceId);
-        }
-      });
+    if (!user || !user.email) { return }
+
+    const deviceId = await popupPostDeviceEvent(user.email);
+    if (!deviceId) {
+      throw new Error("device_idの取得に失敗しました。");
     }
-  })
-}
+
+    const response = await chrome.runtime.sendMessage({
+      action: "updateTimestampAndHistoryEvent",
+      payload: {
+        email: user.email,
+        deviceId: deviceId,
+        timestamp: now.getTime()
+      }
+    });
+
+    console.log('Service Workerからの応答:', response?.status);
+
+  } catch (error) {
+    console.error(`Popup処理中にエラーが発生: ${error.message}`);
+  }
+};
 
 // YYYY/MM/DD形式に変換
 const popupFormatDate = (date) => {
@@ -90,49 +100,6 @@ const popupFormatDate = (date) => {
     return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
   }
   return null;
-};
-
-const popupHistoryEvent = async (email) => {
-  try {
-    const browser = popupHistoryByBrowser();
-    chrome.history.search(popupSearchQuery, async (accessItems) => {
-      try {
-        const data = await popupFormatHistoryData(accessItems);
-
-        fetch(postShadowItUrl, {
-          headers:{
-            'Accept': 'application/json, */*',
-            'Content-type':'application/json'
-          },
-          method: "POST",
-          body: JSON.stringify({
-            email: email,
-            browser: browser,
-            deviceId: deviceId,
-            data: data
-          }),
-        })
-        .catch(error => {
-          sendErrorLog(
-            'popupHistoryEvent_fetch',
-            `Failed to send history data: ${error.message}`,
-            error.stack
-          );
-        });
-
-        popupHistoryLogEvent(email, data);
-      } catch (searchError) {
-        sendErrorLog(
-          'popupHistoryEvent_searchCallback',
-          `Error in popup history search callback: ${searchError.message}`,
-          searchError.stack
-        );
-      }
-    });
-  } catch(e) {
-    console.log(`${e} from popupHistoryEvent`);
-    sendErrorLog('popupHistoryEvent', `Error in popupHistoryEvent: ${e.message}`, e.stack);
-  }
 };
 
 // 履歴取得したブラウザを判別
@@ -145,249 +112,20 @@ const popupHistoryByBrowser = () => {
   }
 };
 
-// UUIDを生成する関数
-const generateUUID = () => {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = Math.random() * 16 | 0;
-    const v = c === 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
-};
-
-const getDeviceInfo = () => {
-  const ua = navigator.userAgent;
-  let osName = "Unknown";
-  let osVersion = "";
-  let browserVersion = "";
-
-  if (ua.indexOf("Windows") !== -1) {
-    osName = "Windows";
-    const match = ua.match(/Windows NT (\d+\.\d+)/);
-    if (match) osVersion = match[1];
-  } else if (ua.indexOf("Mac") !== -1) {
-    osName = "MacOS";
-    const match = ua.match(/Mac OS X (\d+[._]\d+[._]?\d*)/);
-    if (match) osVersion = match[1].replace(/_/g, '.');
-  } else if (ua.indexOf("Linux") !== -1) {
-    osName = "Linux";
-  }
-
-  if (ua.indexOf("Edg") !== -1) {
-    const match = ua.match(/Edg\/(\d+\.\d+\.\d+\.\d+)/);
-    if (match) browserVersion = match[1];
-  } else if (ua.indexOf("Chrome") !== -1) {
-    const match = ua.match(/Chrome\/(\d+\.\d+\.\d+\.\d+)/);
-    if (match) browserVersion = match[1];
-  }
-
-  return {
-    os: osName,
-    osVersion: osVersion,
-    browserVersion: browserVersion,
-    language: navigator.language,
-    platform: navigator.platform
-  };
-};
-
-const sendErrorLog = (functionName, errorMessage, errorStack, level = "error") => {
-  try {
-    chrome.identity.getProfileUserInfo((user) => {
-      if (!user || !user.email) {
-        console.error("[ITboard] ユーザー情報が取得できませんでした");
-        return;
-      }
-
-      const browser = popupHistoryByBrowser();
-      const timestamp = new Date().toISOString();
-
-      // 送信データの作成
-      const errorData = {
-        email: user.email,
-        browser: browser,
-        data: {
-          function: functionName,
-          message: errorMessage,
-          stack: errorStack || "",
-          timestamp: timestamp
-        },
-        level: level
-      };
-
-      fetch(postErrorLogUrl, {
-        headers: {
-          'Accept': 'application/json, */*',
-          'Content-type': 'application/json'
-        },
-        method: 'POST',
-        body: JSON.stringify(errorData)
-      })
-      .then(response => {
-        if (response.ok) {
-          console.log(`[ITboard] エラーログ送信成功: ${functionName}`);
-        } else {
-          console.error(`[ITboard] エラーログ送信失敗: ${response.status}`);
-        }
-      })
-      .catch(err => {
-        console.error(`[ITboard] エラーログ送信中に例外が発生: ${err}`);
-      });
-    });
-  } catch (e) {
-    console.error(`[ITboard] sendErrorLog内で例外が発生: ${e}`);
-  }
-};
-
-const popupHistoryLogEvent = async (email, preloadedData) => {
-  try {
-    const browser = popupHistoryByBrowser();
-    const sendId = generateUUID();
-    const timestamp = new Date().toISOString();
-    const manifest = chrome.runtime.getManifest();
-    const deviceInfo = getDeviceInfo();
-
-    const data = preloadedData;
-    sendPopupHistoryLogData(email, browser, data, sendId, timestamp, manifest, deviceInfo);
-  } catch (e) {
-    console.error(`${e} from popupHistoryLogEvent`);
-    sendErrorLog('popupHistoryLogEvent', `Error in popupHistoryLogEvent: ${e.message}`, e.stack);
-  }
-};
-
-const sendPopupHistoryLogData = (email, browser, data, sendId, timestamp, manifest, deviceInfo) => {
-  const sendData = {
-    email: email,
-    browser: browser,
-    data: data,
-    metadata: {
-      sendId: sendId,
-      timestamp: timestamp,
-      clientVersion: manifest.version,
-      extensionId: chrome.runtime.id,
-      deviceInfo: deviceInfo
-    },
-    status: {
-      sendStatus: "initial",
-      dataCount: data.length,
-      compressed: false
-    }
-  };
-
-  fetch(postHistoryLogUrl, {
-    headers: {
-      'Accept': 'application/json, */*',
-      'Content-type': 'application/json'
-    },
-    method: 'POST',
-    body: JSON.stringify(sendData)
-  })
-  .then(response => {
-    if (response.ok) {
-      return response.text().then(text => {
-        let result = {};
-        try {
-          if (text) result = JSON.parse(text);
-        } catch (e) {
-          console.log('Response is not JSON:', text);
-        }
-        return result;
-      });
-    } else {
-      throw new Error(`HTTP error: ${response.status}`);
-    }
-  })
-  .then(result => {
-    console.log('History log success:', result);
-  })
-  .catch(error => {
-    console.error('History log error:', error);
-
-    sendErrorLog(
-      'popupHistoryLogEvent_fetch',
-      `Failed to send history log: ${error.message}`,
-      error.stack
-    );
-  });
-};
-
-const popupFormatHistoryData = async (accessItems) => {
-  const accessArray = [];
-
-  const promises = accessItems.map(item => {
-    return new Promise(resolve => {
-      const urlObj = { url: item.url };
-
-      chrome.history.getVisits(urlObj, (gettingVisits) => {
-        let latestVisit = null;
-        let latestTime = new Date(0);
-
-        for (let n = 0; n < gettingVisits.length; n++) {
-          const visitData = gettingVisits[n];
-          const visitTime = new Date(visitData.visitTime);
-          const now = new Date();
-          const visitRange = new Date(now.setDate(now.getDate() - popupDateRange));
-
-          // 指定期間(過去60日間)以内のデータのみ処理
-          if (visitTime > visitRange) {
-            if (visitTime > latestTime) {
-              latestTime = visitTime;
-              latestVisit = {
-                url: item.url.replace(/\?.*$/, ""),
-                title: item.title,
-                lastAccessDate: visitTime
-              };
-            }
-          }
-        }
-
-        if (latestVisit) {
-          accessArray.push(latestVisit);
-        }
-
-        resolve();
-      });
-    });
-  });
-
-  await Promise.all(promises);
-
-  return accessArray;
-};
-
 const popupPostDeviceEvent = async (email) => {
   try {
-    const storage = await chrome.storage.local.get('device_id');
-
-    if (storage.device_id) {
-      return storage.device_id;
-    }
-
-    const browser = popupHistoryByBrowser();
-
-    const response = await fetch(con.deviceUrl, {
-      headers:{
-        'Accept': 'application/json, */*',
-        'Content-type':'application/json'
-      },
-      method: 'POST',
-      body: JSON.stringify({ email, browser }),
+    const response = await chrome.runtime.sendMessage({
+      action: "getOrCreateDeviceId",
+      payload: { email }
     });
-
-    if (!response.ok) {
-      throw new Error(`[ITboard] device 作成リクエスト失敗: ${response.status}`);
+    if (!response || !response.deviceId) {
+      throw new Error("Service Workerから有効なdeviceIdが返されませんでした。");
     }
 
-    const data = await response.json();
-    const deviceId = data.device_id;
+    return response.deviceId;
 
-    if (deviceId) {
-      chrome.storage.local.set({ device_id: deviceId });
-      return deviceId;
-    } else {
-      throw new Error(`[ITboard] device_id がレスポンスに含まれていません`);
-    }
-
-  } catch (e) {
-    console.error(e.message);
+  } catch (error) {
+    console.error(`[ITboard] device_idの取得に失敗しました: ${error.message}`);
     return null;
   }
 };
@@ -395,35 +133,11 @@ const popupPostDeviceEvent = async (email) => {
 // ローカル確認用
 const postDistributeUrl =
   "http://localhost:3000/v1/browser-extensions/distribute";
-const postShadowItUrl =
-  "http://localhost:3000/v1/browser-extensions/browsing-histories_with_device";
-const postHistoryLogUrl =
-  "http://localhost:3000/v1/browser-extension-logs/history";
-const postErrorLogUrl =
-  "http://localhost:3000/v1/browser-extension-logs";
-const deviceUrl =
-  "http://localhost:3000/v1/extension_browsing_history_devices"
 
 // STG確認用
 // const postDistributeUrl =
 //   'https://stg-01.itboard.jp/api/v1/browser-extensions/distribute'
-// const postShadowItUrl =
-//   'https://stg-01.itboard.jp/api/v1/browser-extensions/browsing-histories_with_device'
-// const postHistoryLogUrl =
-//   'https://stg-01.itboard.jp/api/v1/browser-extension-logs/history'
-// const postErrorLogUrl =
-//   'https://stg-01.itboard.jp/api/v1/browser-extension-logs'
-// const deviceUrl =
-//   "https://stg-01.itboard.jp/api/v1/extension_browsing_history_devices"
 
 // 本番用
 // const postDistributeUrl =
 //   'https://www.itboard.jp/api/v1/browser-extensions/distribute'
-// const postShadowItUrl =
-//   'https://www.itboard.jp/api/v1/browser-extensions/browsing-histories_with_device'
-// const postHistoryLogUrl =
-//   'https://www.itboard.jp/api/v1/browser-extension-logs/history'
-// const postErrorLogUrl =
-//   'https://www.itboard.jp/api/v1/browser-extension-logs'
-// const deviceUrl =
-//   "https://www.itboard.jp/api/v1/extension_browsing_history_devices"


### PR DESCRIPTION
## チケット
[ITBOARD-3410](https://itcrowd.backlog.com/view/ITBOARD-3410) 同一人物の複数環境からのブラウザ履歴を検知できるようにする

## 対応内容
[backlogチケット詳細の「設計＞拡張機能側」項目](https://itcrowd.backlog.com/view/ITBOARD-3410#:~:text=%E8%A8%AD%E8%A8%88-,%E6%8B%A1%E5%BC%B5%E6%A9%9F%E8%83%BD%E5%81%B4,-device_id%20%E3%81%A7%E5%B1%A5%E6%AD%B4)に記載
また、全体的に非同期処理がコールバックで実装されており可読性が低く、実装もしづらかったため、主にasync/await を用いた記述に修正しました。

## Rails側のチケット
https://github.com/SB-CORP-ITboard/ITboard/pull/1450

## RV期限
6月18日(水)